### PR TITLE
fix: update semantic-release-action to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         cd ./sample/
         ./gradlew test
     - name: Release
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@v3
       with:
         extra_plugins: |
           "@semantic-release/commit-analyzer"


### PR DESCRIPTION
Builds started breaking 3 weeks ago. This fixes it. https://github.com/googlemaps/java-fleetengine-auth/actions/workflows/main.yml